### PR TITLE
[2.070] modify stomping control patch

### DIFF
--- a/patches/druntime/0001-Pick-upstream-GC.stats-implementation.patch
+++ b/patches/druntime/0001-Pick-upstream-GC.stats-implementation.patch
@@ -1,7 +1,7 @@
-From b96097c11822f2e1760567c41be64cbc9c65134b Mon Sep 17 00:00:00 2001
+From 24659c667dbf20693cbfe713bd1527e527adf004 Mon Sep 17 00:00:00 2001
 From: Mathias Lang <mathias.lang@sociomantic.com>
 Date: Fri, 24 Jul 2015 17:57:13 +0200
-Subject: [PATCH 01/13] Pick upstream GC.stats implementation
+Subject: [PATCH 01/19] Pick upstream GC.stats implementation
 
 Picks changes from https://github.com/dlang/druntime/pull/1610
 ---
@@ -37,10 +37,11 @@ index c222831..9996a74 100644
  
      extern (C) void gc_addRoot( in void* p ) nothrow;
      extern (C) void gc_addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
-@@ -157,6 +158,17 @@ struct GC
+@@ -156,6 +157,17 @@ struct GC
+ {
      @disable this();
  
-     /**
++    /**
 +     * Aggregation of GC stats to be exposed via public API
 +     */
 +    static struct Stats
@@ -51,10 +52,9 @@ index c222831..9996a74 100644
 +        size_t freeSize;
 +    }
 +
-+    /**
+     /**
       * Enables automatic garbage collection behavior if collections have
       * previously been suspended by a call to disable.  This function is
-      * reentrant, and must be called once for every call to disable before
 @@ -657,6 +669,14 @@ struct GC
          return gc_query( p );
      }
@@ -273,5 +273,5 @@ index 2d6a01a..0000000
 -    size_t pageblocks;      // number of blocks marked PAGE
 -}
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0002-Stomping-control-implementation.patch
+++ b/patches/druntime/0002-Stomping-control-implementation.patch
@@ -1,12 +1,12 @@
-From 9c40b4a69b772e2771d54f685c0a5f7a4a5193c5 Mon Sep 17 00:00:00 2001
+From fd7ba6121a08168bf8ee31e2974fd41250e4a5b8 Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Sun, 6 Sep 2015 05:38:41 +0300
-Subject: [PATCH 02/13] Stomping control implementation
+Subject: [PATCH 02/19] Stomping control implementation
 
 ---
  posix.mak         |  8 ++++--
- src/rt/lifetime.d | 80 ++++++++++++++++++++++++++++++++++++++++++++++++++++---
- 2 files changed, 82 insertions(+), 6 deletions(-)
+ src/rt/lifetime.d | 82 ++++++++++++++++++++++++++++++++++++++++++++++++++++---
+ 2 files changed, 84 insertions(+), 6 deletions(-)
 
 diff --git a/posix.mak b/posix.mak
 index 7175f0f..12dca19 100644
@@ -15,13 +15,13 @@ index 7175f0f..12dca19 100644
 @@ -3,6 +3,10 @@
  #    pkg_add -r gmake
  # and then run as gmake rather than make.
- 
+
 +# Don't assert on stomping prevention during tests or any other internal targets
 +# See https://github.com/sociomantic/druntime/pull/14 for details
 +export ASSERT_ON_STOMPING_PREVENTION=0
 +
  QUIET:=@
- 
+
  include osmodel.mak
 @@ -53,10 +57,10 @@ endif
  # Set DFLAGS
@@ -35,9 +35,9 @@ index 7175f0f..12dca19 100644
 +	UDFLAGS += -O -release -g -debug=CheckStompingPrevention
  	DFLAGS:=$(UDFLAGS) -inline # unittests don't compile with -inline
  endif
- 
+
 diff --git a/src/rt/lifetime.d b/src/rt/lifetime.d
-index d28edf8..24c6d90 100644
+index d28edf8..ac3ad76 100644
 --- a/src/rt/lifetime.d
 +++ b/src/rt/lifetime.d
 @@ -17,7 +17,7 @@ import core.stdc.string;
@@ -47,12 +47,12 @@ index d28edf8..24c6d90 100644
 -debug(PRINTF) import core.stdc.stdio;
 +debug import core.stdc.stdio;
  static import rt.tlsgc;
- 
+
  alias BlkInfo = GC.BlkInfo;
-@@ -230,6 +230,57 @@ size_t structTypeInfoSize(const TypeInfo ti) pure nothrow @nogc
+@@ -230,6 +230,59 @@ size_t structTypeInfoSize(const TypeInfo ti) pure nothrow @nogc
  private class ArrayAllocLengthLock
  {}
- 
+
 +// break on this to debug stomping prevention allocations
 +export extern(C) void stomping_prevention_trigger ( ) pure nothrow
 +{
@@ -70,7 +70,9 @@ index d28edf8..24c6d90 100644
 +    import core.stdc.stdio : fflush, stdout, printf;
 +    import core.stdc.string : strcmp;
 +
-+    const failure = new Exception("Stoming prevention has been triggerred");
++    static Exception failure;
++    if (failure is null)
++        failure = new Exception("Stomping prevention has been triggered");
 +
 +    try
 +    {
@@ -104,10 +106,10 @@ index d28edf8..24c6d90 100644
 +        abort();
 +    }
 +}
- 
+
  /**
    Set the allocated length of the array block.  This is called
-@@ -282,14 +333,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
+@@ -282,14 +335,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
          {
              if(isshared)
              {
@@ -130,7 +132,7 @@ index d28edf8..24c6d90 100644
              }
          }
          else
-@@ -313,14 +371,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
+@@ -313,14 +373,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
          {
              if(isshared)
              {
@@ -153,7 +155,7 @@ index d28edf8..24c6d90 100644
              }
          }
          else
-@@ -344,14 +409,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
+@@ -344,14 +411,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
          {
              if(isshared)
              {
@@ -176,6 +178,6 @@ index d28edf8..24c6d90 100644
              }
          }
          else
--- 
-2.7.4
+--
+2.14.1
 

--- a/patches/druntime/0003-Add-message-to-object.Throwable.patch
+++ b/patches/druntime/0003-Add-message-to-object.Throwable.patch
@@ -1,7 +1,7 @@
-From 831698091b0d4cbd7aa88522bb0fa5af3315cfe9 Mon Sep 17 00:00:00 2001
+From 9aa64b2684b734a94ed7ef6790d9d6863588e3b4 Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Tue, 9 Feb 2016 22:24:24 +0200
-Subject: [PATCH 03/13] Add message() to object.Throwable
+Subject: [PATCH 03/19] Add message() to object.Throwable
 
 ---
  src/object.d | 15 +++++++++++++++
@@ -11,10 +11,11 @@ diff --git a/src/object.d b/src/object.d
 index f0eb55a..e9ae3c6 100644
 --- a/src/object.d
 +++ b/src/object.d
-@@ -1623,6 +1623,19 @@ class Throwable : Object
+@@ -1622,6 +1622,19 @@ class Throwable : Object
+ 
      string      msg;    /// A message describing the error.
  
-     /**
++    /**
 +     * Get the message describing the error.
 +     * Base behavior is to return the `Throwable.msg` field.
 +     * Override to return some other error message.
@@ -27,10 +28,9 @@ index f0eb55a..e9ae3c6 100644
 +        return msg;
 +    }
 +
-+    /**
+     /**
       * The _file name and line number of the D source code corresponding with
       * where the error was thrown from.
-      */
 @@ -1689,6 +1702,8 @@ class Throwable : Object
          sink("@"); sink(file);
          sink("("); sink(sizeToTempString(line, tmpBuff, 10)); sink(")");
@@ -41,5 +41,5 @@ index f0eb55a..e9ae3c6 100644
          {
              sink(": "); sink(msg);
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0004-Add-core.sys.posix.mqueue-C-bindings-for-POSIX-s-mqu.patch
+++ b/patches/druntime/0004-Add-core.sys.posix.mqueue-C-bindings-for-POSIX-s-mqu.patch
@@ -1,7 +1,7 @@
-From 6c566f087ff3824cfaeca1755bfd68a32ccdb5f4 Mon Sep 17 00:00:00 2001
+From 5bf70479e6808e5087759dcc319f4ce67de6f1b2 Mon Sep 17 00:00:00 2001
 From: Mathias Lang <mathias.lang@sociomantic.com>
 Date: Tue, 26 Jan 2016 18:50:33 +0100
-Subject: [PATCH 04/13] Add core.sys.posix.mqueue, C bindings for POSIX's
+Subject: [PATCH 04/19] Add core.sys.posix.mqueue, C bindings for POSIX's
  <mqueue.h>
 
 This is a binding for POSIX message queues.
@@ -237,5 +237,5 @@ index 0000000..67ea678
 +int mq_timedsend (mqd_t mqdes, const(char)* msg_ptr, size_t msg_len,
 +                   uint msg_prio, const(timespec)* abs_timeout);
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0005-Add-bindings-for-getifaddrs-freeifaddrs.patch
+++ b/patches/druntime/0005-Add-bindings-for-getifaddrs-freeifaddrs.patch
@@ -1,7 +1,7 @@
-From 5e01d6761c71cf3955cb78d4ec17655bbdfc75c5 Mon Sep 17 00:00:00 2001
+From 1dcae3226621bcfc3b96ac55f6706f69a86bc909 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Fri, 25 Nov 2016 17:04:07 +0100
-Subject: [PATCH 05/13] Add bindings for getifaddrs/freeifaddrs
+Subject: [PATCH 05/19] Add bindings for getifaddrs/freeifaddrs
 
 ---
  mak/COPY                     |  1 +
@@ -112,5 +112,5 @@ index f2ae0a3..bcc1ee9 100644
  	copy $** $@
  
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0006-Add-TCP_-constants-from-Linux-s-netinet-tcp.h.patch
+++ b/patches/druntime/0006-Add-TCP_-constants-from-Linux-s-netinet-tcp.h.patch
@@ -1,7 +1,7 @@
-From 4f8383f237c08345c81ab4c2d6a7a819aaa7c6d4 Mon Sep 17 00:00:00 2001
+From 8d9fd84057d25abe16dc244753f4448b50dd9586 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Mon, 28 Nov 2016 18:44:19 +0100
-Subject: [PATCH 06/13] Add TCP_* constants from Linux's netinet/tcp.h
+Subject: [PATCH 06/19] Add TCP_* constants from Linux's netinet/tcp.h
 
 ---
  mak/COPY                             |  1 +
@@ -137,5 +137,5 @@ index bcc1ee9..1f09673 100644
  	copy $** $@
  
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0007-Add-bindings-for-POSIX-iconv.patch
+++ b/patches/druntime/0007-Add-bindings-for-POSIX-iconv.patch
@@ -1,7 +1,7 @@
-From e03d84e9d45be9041d8c29496b7b13f0506ec562 Mon Sep 17 00:00:00 2001
+From d8f4965067de28ef75ea51e7144ed3f70da95cb5 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Thu, 24 Nov 2016 13:48:53 +0100
-Subject: [PATCH 07/13] Add bindings for POSIX iconv
+Subject: [PATCH 07/19] Add bindings for POSIX iconv
 
 ---
  mak/COPY                   |  1 +
@@ -102,5 +102,5 @@ index 1f09673..c2ea1a8 100644
  	copy $** $@
  
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0008-Add-Linux-specific-sched_setaffinity-and-sched_getaf.patch
+++ b/patches/druntime/0008-Add-Linux-specific-sched_setaffinity-and-sched_getaf.patch
@@ -1,7 +1,7 @@
-From 9185a581a06e32b520dee02c471c08a9681d7853 Mon Sep 17 00:00:00 2001
+From babe4480f80dcc213d2a70d70d3ff4dd832235c9 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Tue, 29 Nov 2016 10:37:13 +0100
-Subject: [PATCH 08/13] Add Linux-specific sched_setaffinity and
+Subject: [PATCH 08/19] Add Linux-specific sched_setaffinity and
  sched_getaffinity
 
 ---
@@ -139,5 +139,5 @@ index c2ea1a8..ed201b8 100644
  	copy $** $@
  
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0009-Add-missing-POSIX-libgen.h-header.patch
+++ b/patches/druntime/0009-Add-missing-POSIX-libgen.h-header.patch
@@ -1,7 +1,7 @@
-From 9a2501e8f24f2625895e9eb5eda339a33117da7c Mon Sep 17 00:00:00 2001
+From 1e3afc43be8c14a64ced38a35e542719a1304a60 Mon Sep 17 00:00:00 2001
 From: Leandro Lucarella <leandro.lucarella@sociomantic.com>
 Date: Thu, 24 Nov 2016 20:05:48 -0300
-Subject: [PATCH 09/13] Add missing POSIX <libgen.h> header
+Subject: [PATCH 09/19] Add missing POSIX <libgen.h> header
 
 ---
  mak/COPY                    |  1 +
@@ -80,5 +80,5 @@ index ed201b8..3ef7f10 100644
  	copy $** $@
  
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0010-Add-missing-binding-in-SRCS.patch
+++ b/patches/druntime/0010-Add-missing-binding-in-SRCS.patch
@@ -1,7 +1,7 @@
-From dde162b9fb202c58767335bca22623f5b6118e6c Mon Sep 17 00:00:00 2001
+From efe9625a4ef571d0440bb4177f1ddc60b84d9471 Mon Sep 17 00:00:00 2001
 From: Mathias Lang <mathias.lang@sociomantic.com>
 Date: Mon, 6 Feb 2017 17:20:57 +0100
-Subject: [PATCH 10/13] Add missing binding in SRCS
+Subject: [PATCH 10/19] Add missing binding in SRCS
 
 The following files were not part of `mak/SRCS`, and thus were not compiled it:
 - src\core\sys\posix\sys\ipc.d
@@ -72,5 +72,5 @@ index 49fb7e1..95c84f7 100644
  	src\core\sys\solaris\sys\priocntl.d \
  	src\core\sys\solaris\sys\types.d \
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0011-Change-version-Linux-to-version-linux.patch
+++ b/patches/druntime/0011-Change-version-Linux-to-version-linux.patch
@@ -1,7 +1,7 @@
-From 72f753acf691b80717616777b4ffa57849ad3abb Mon Sep 17 00:00:00 2001
+From 42f95e9938be1f7cf8ebdc22929b11c48af141e8 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Fri, 24 Feb 2017 16:12:35 +0100
-Subject: [PATCH 11/13] Change version(Linux) to version(linux)
+Subject: [PATCH 11/19] Change version(Linux) to version(linux)
 
 ---
  src/core/sys/linux/sched.d           | 2 +-
@@ -35,5 +35,5 @@ index b4acdd2..67458f6 100644
  /// User-settable options (used with setsockopt).
  enum
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0012-Fix-wrong-version-name-in-core.sys.linux.ifaddrs.patch
+++ b/patches/druntime/0012-Fix-wrong-version-name-in-core.sys.linux.ifaddrs.patch
@@ -1,7 +1,7 @@
-From 7363c6f533f1edd0e5489affa3cb1f1d0c64e3be Mon Sep 17 00:00:00 2001
+From fba969f8824732eff7d6866a1f414bd91fa90437 Mon Sep 17 00:00:00 2001
 From: Tomer Filiba <tomer@weka.io>
 Date: Tue, 21 Feb 2017 18:15:24 +0200
-Subject: [PATCH 12/13] Fix wrong version name in core.sys.linux.ifaddrs
+Subject: [PATCH 12/19] Fix wrong version name in core.sys.linux.ifaddrs
 
 ---
  src/core/sys/linux/ifaddrs.d | 2 +-
@@ -21,5 +21,5 @@ index 1fc5e88..bfdd59b 100644
  nothrow:
  @nogc:
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0013-linux-time-Add-timer-manipulation-macros.patch
+++ b/patches/druntime/0013-linux-time-Add-timer-manipulation-macros.patch
@@ -1,7 +1,7 @@
-From 30543347349e9ef75499437fd0085b374962dfe0 Mon Sep 17 00:00:00 2001
+From 159ef202ae34d79be58a0ecba1a19bdf37ab1093 Mon Sep 17 00:00:00 2001
 From: Leandro Lucarella <leandro.lucarella@sociomantic.com>
 Date: Fri, 25 Nov 2016 17:07:36 -0300
-Subject: [PATCH 13/13] linux/time: Add timer manipulation macros
+Subject: [PATCH 13/19] linux/time: Add timer manipulation macros
 
 ---
  mak/COPY                      |  1 +
@@ -119,5 +119,5 @@ index dbeb58a..33793da 100644
  extern (C) nothrow @nogc:
  
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0014-Temporarily-allow-deprecated-GC.usage.patch
+++ b/patches/druntime/0014-Temporarily-allow-deprecated-GC.usage.patch
@@ -1,7 +1,7 @@
-From b30e2cb68f42b52ea5d9a2bd594124c27b8c1733 Mon Sep 17 00:00:00 2001
+From 414f58330ef16261553481e14283c167aa4f5e0a Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Tue, 28 Feb 2017 15:28:15 +0100
-Subject: [PATCH 14/14] Temporarily allow deprecated GC.usage
+Subject: [PATCH 14/19] Temporarily allow deprecated GC.usage
 
 Matches old API in D1 runtime
 ---
@@ -28,5 +28,5 @@ index 9996a74..aaa7566 100644
       * Adds an internal root pointing to the GC memory block referenced by p.
       * As a result, the block referenced by p itself and any blocks accessible
 -- 
-2.7.4
+2.14.1
 

--- a/patches/druntime/0015-Add-bindings-for-POSIX-getdelim-and-getline.patch
+++ b/patches/druntime/0015-Add-bindings-for-POSIX-getdelim-and-getline.patch
@@ -1,14 +1,14 @@
-From 822813dd259c0341a99f78ac6e8ddffdd91bfbe3 Mon Sep 17 00:00:00 2001
+From ca657c404dc8d8e945a6d30cae374eb7819c544d Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Thu, 26 Jan 2017 18:52:49 +0100
-Subject: [PATCH] Add bindings for POSIX getdelim and getline
+Subject: [PATCH 15/19] Add bindings for POSIX getdelim and getline
 
 ---
  src/core/sys/posix/stdio.d | 4 ++++
  1 file changed, 4 insertions(+)
 
 diff --git a/src/core/sys/posix/stdio.d b/src/core/sys/posix/stdio.d
-index 122cba07..6cc30a99 100644
+index 122cba0..6cc30a9 100644
 --- a/src/core/sys/posix/stdio.d
 +++ b/src/core/sys/posix/stdio.d
 @@ -321,3 +321,7 @@ unittest
@@ -20,5 +20,5 @@ index 122cba07..6cc30a99 100644
 +ssize_t getdelim (char** lineptr, size_t* n, int delimiter, FILE* stream);
 +ssize_t getline (char** lineptr, size_t* n, FILE* stream);
 -- 
-2.12.1
+2.14.1
 

--- a/patches/druntime/0016-Add-eventfd-bindings.patch
+++ b/patches/druntime/0016-Add-eventfd-bindings.patch
@@ -1,7 +1,7 @@
-From e4b0121edaf47139ffe4af27f126767536fa6a42 Mon Sep 17 00:00:00 2001
+From 902f486fed193d663dce4a33ae86044723ce724b Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Tue, 4 Apr 2017 15:27:57 +0200
-Subject: [PATCH] Add eventfd bindings
+Subject: [PATCH 16/19] Add eventfd bindings
 
 This adds bindings for linux-specific eventfd_* calls.
 
@@ -15,7 +15,7 @@ Cherry-pick of https://github.com/dlang/druntime/pull/1800/commits/0748d402f4dcf
  create mode 100644 src/core/sys/linux/sys/eventfd.d
 
 diff --git a/mak/COPY b/mak/COPY
-index 4fe11f25..e36d1a2a 100644
+index 4fe11f2..e36d1a2 100644
 --- a/mak/COPY
 +++ b/mak/COPY
 @@ -72,6 +72,7 @@ COPY=\
@@ -28,7 +28,7 @@ index 4fe11f25..e36d1a2a 100644
  	$(IMPDIR)\core\sys\linux\sys\netinet\tcp.d \
 diff --git a/src/core/sys/linux/sys/eventfd.d b/src/core/sys/linux/sys/eventfd.d
 new file mode 100644
-index 00000000..f0e56195
+index 0000000..f0e5619
 --- /dev/null
 +++ b/src/core/sys/linux/sys/eventfd.d
 @@ -0,0 +1,85 @@
@@ -118,7 +118,7 @@ index 00000000..f0e56195
 +else
 +    static assert(0, "unimplemented");
 diff --git a/win32.mak b/win32.mak
-index f54c6ba4..cc837563 100644
+index f54c6ba..cc83756 100644
 --- a/win32.mak
 +++ b/win32.mak
 @@ -415,6 +415,9 @@ $(IMPDIR)\core\sys\linux\tipc.d : src\core\sys\linux\tipc.d
@@ -132,7 +132,7 @@ index f54c6ba4..cc837563 100644
  	copy $** $@
  
 diff --git a/win64.mak b/win64.mak
-index 3ef7f107..7454955c 100644
+index 3ef7f10..7454955 100644
 --- a/win64.mak
 +++ b/win64.mak
 @@ -423,6 +423,9 @@ $(IMPDIR)\core\sys\linux\tipc.d : src\core\sys\linux\tipc.d
@@ -146,5 +146,5 @@ index 3ef7f107..7454955c 100644
  	copy $** $@
  
 -- 
-2.12.2
+2.14.1
 

--- a/patches/druntime/0017-Add-Fiber-s-guard-page-in-Posix-as-well.patch
+++ b/patches/druntime/0017-Add-Fiber-s-guard-page-in-Posix-as-well.patch
@@ -1,7 +1,7 @@
-From 9893aefd4dd16c14e7198fa82c314bcdeb4e9d0e Mon Sep 17 00:00:00 2001
+From 61f52b81954cadddca0a97f8ab47575dec9883bc Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Thu, 24 Nov 2016 17:25:39 +0100
-Subject: [PATCH] Add Fiber's guard page in Posix as well
+Subject: [PATCH 17/19] Add Fiber's guard page in Posix as well
 
 Windows Fiber implementation already uses the fiber stack guard page.
 This brings the similar protection for mmaped fiber stacks, using
@@ -20,7 +20,7 @@ Fiber's constructor's parameter `guard_page_size`.
 
 diff --git a/changelog/fiber-configure.dd b/changelog/fiber-configure.dd
 new file mode 100644
-index 00000000..23267356
+index 0000000..2326735
 --- /dev/null
 +++ b/changelog/fiber-configure.dd
 @@ -0,0 +1,6 @@
@@ -32,7 +32,7 @@ index 00000000..23267356
 +turn this feature off.
 diff --git a/changelog/fiber.dd b/changelog/fiber.dd
 new file mode 100644
-index 00000000..926dfa1f
+index 0000000..926dfa1
 --- /dev/null
 +++ b/changelog/fiber.dd
 @@ -0,0 +1,9 @@
@@ -46,7 +46,7 @@ index 00000000..926dfa1f
 +before or after stack pointer and it can be seen if it contains END OF FIBER
 +string pattern.
 diff --git a/src/core/thread.d b/src/core/thread.d
-index 88b7708f..52c5b426 100644
+index 88b7708..52c5b42 100644
 --- a/src/core/thread.d
 +++ b/src/core/thread.d
 @@ -3937,18 +3937,21 @@ class Fiber
@@ -194,5 +194,5 @@ index 88b7708f..52c5b426 100644
  
          Thread.add( m_ctxt );
 -- 
-2.12.2
+2.14.1
 

--- a/patches/druntime/0018-Disable-copying-of-inotify_event.patch
+++ b/patches/druntime/0018-Disable-copying-of-inotify_event.patch
@@ -1,7 +1,7 @@
-From 1ff484991829209f6eb265b5b4f4d9fc141f5f0f Mon Sep 17 00:00:00 2001
+From 85d800c2a9d3f4871bc83a8294cbc38ca91b19a4 Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns@gmail.com>
 Date: Fri, 28 Apr 2017 17:04:15 +0200
-Subject: [PATCH] Disable copying of inotify_event
+Subject: [PATCH 18/19] Disable copying of inotify_event
 
 Pick of https://github.com/dlang/druntime/pull/1795
 ---
@@ -9,7 +9,7 @@ Pick of https://github.com/dlang/druntime/pull/1795
  1 file changed, 2 insertions(+)
 
 diff --git a/src/core/sys/linux/sys/inotify.d b/src/core/sys/linux/sys/inotify.d
-index 41ad65c2..0e273c63 100644
+index 41ad65c..0e273c6 100644
 --- a/src/core/sys/linux/sys/inotify.d
 +++ b/src/core/sys/linux/sys/inotify.d
 @@ -18,6 +18,8 @@ struct inotify_event
@@ -22,5 +22,5 @@ index 41ad65c2..0e273c63 100644
  
  enum: uint
 -- 
-2.12.2
+2.14.1
 

--- a/patches/druntime/0019-Don-t-trigger-stomping-prevention-with-cov.patch
+++ b/patches/druntime/0019-Don-t-trigger-stomping-prevention-with-cov.patch
@@ -1,7 +1,7 @@
-From d1ba6a921faaa77ff0ccac7891ab840be62bd0ea Mon Sep 17 00:00:00 2001
+From 887694fcd48e56bd1cf24116f789fcdb45527152 Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Thu, 31 Aug 2017 14:49:04 +0300
-Subject: [PATCH] Don't trigger stomping prevention with -cov
+Subject: [PATCH 19/19] Don't trigger stomping prevention with -cov
 
 ---
  src/rt/cover.d | 5 +++++


### PR DESCRIPTION
Regenarated patches after this change:

```diff
diff --git a/src/rt/lifetime.d b/src/rt/lifetime.d
index 24c6d90..ac3ad76 100644
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -247,7 +247,9 @@ void stomping_prevention_trigger_nonpure ( ) nothrow
     import core.stdc.stdio : fflush, stdout, printf;
     import core.stdc.string : strcmp;

-    const failure = new Exception("Stoming prevention has been triggerred");
+    static Exception failure;
+    if (failure is null)
+        failure = new Exception("Stoming prevention has been triggerred");

     try
     {
```

Fixes repeated allocation of exception thrown to get call stack when
trigger is hit.