### PR TITLE
[2.071] modify stomping control patch

### DIFF
--- a/patches/druntime/0001-Pick-upstream-GC.stats-implementation.patch
+++ b/patches/druntime/0001-Pick-upstream-GC.stats-implementation.patch
@@ -1,7 +1,7 @@
-From 13e0ebebcb60ac29889700544c57a73c4c9af585 Mon Sep 17 00:00:00 2001
+From b0e3d7061baeda29943d22c9353df8a8c947043b Mon Sep 17 00:00:00 2001
 From: Mathias Lang <mathias.lang@sociomantic.com>
 Date: Fri, 24 Jul 2015 17:57:13 +0200
-Subject: [PATCH 01/17] Pick upstream GC.stats implementation
+Subject: [PATCH 01/18] Pick upstream GC.stats implementation
 
 Picks changes from https://github.com/dlang/druntime/pull/1610
 ---
@@ -37,10 +37,11 @@ index 22e2fe9b..bdc6bc42 100644
  
      extern (C) void gc_addRoot( in void* p ) nothrow;
      extern (C) void gc_addRange( in void* p, size_t sz, const TypeInfo ti = null ) nothrow @nogc;
-@@ -159,6 +160,17 @@ struct GC
+@@ -158,6 +159,17 @@ struct GC
+ {
      @disable this();
  
-     /**
++    /**
 +     * Aggregation of GC stats to be exposed via public API
 +     */
 +    static struct Stats
@@ -51,10 +52,9 @@ index 22e2fe9b..bdc6bc42 100644
 +        size_t freeSize;
 +    }
 +
-+    /**
+     /**
       * Enables automatic garbage collection behavior if collections have
       * previously been suspended by a call to disable.  This function is
-      * reentrant, and must be called once for every call to disable before
 @@ -659,6 +671,14 @@ struct GC
          return gc_query( p );
      }
@@ -271,5 +271,5 @@ index 2d6a01a3..00000000
 -    size_t pageblocks;      // number of blocks marked PAGE
 -}
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0002-Stomping-control-implementation.patch
+++ b/patches/druntime/0002-Stomping-control-implementation.patch
@@ -1,12 +1,12 @@
-From 093e2409b0ca8e8827864765ce21b989884cce72 Mon Sep 17 00:00:00 2001
+From 90c49a34856cef5c893582e27cba271dec8ac25e Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Sun, 6 Sep 2015 05:38:41 +0300
-Subject: [PATCH 02/17] Stomping control implementation
+Subject: [PATCH 02/18] Stomping control implementation
 
 ---
  posix.mak         |  8 ++++--
- src/rt/lifetime.d | 80 ++++++++++++++++++++++++++++++++++++++++++++++++++++---
- 2 files changed, 82 insertions(+), 6 deletions(-)
+ src/rt/lifetime.d | 82 ++++++++++++++++++++++++++++++++++++++++++++++++++++---
+ 2 files changed, 84 insertions(+), 6 deletions(-)
 
 diff --git a/posix.mak b/posix.mak
 index 91c30606..b55c8a56 100644
@@ -15,13 +15,13 @@ index 91c30606..b55c8a56 100644
 @@ -3,6 +3,10 @@
  #    pkg_add -r gmake
  # and then run as gmake rather than make.
- 
+
 +# Don't assert on stomping prevention during tests or any other internal targets
 +# See https://github.com/sociomantic/druntime/pull/14 for details
 +export ASSERT_ON_STOMPING_PREVENTION=0
 +
  QUIET:=
- 
+
  include osmodel.mak
 @@ -53,10 +57,10 @@ endif
  # Set DFLAGS
@@ -35,9 +35,9 @@ index 91c30606..b55c8a56 100644
 +	UDFLAGS += -O -release -g -debug=CheckStompingPrevention
  	DFLAGS:=$(UDFLAGS) -inline # unittests don't compile with -inline
  endif
- 
+
 diff --git a/src/rt/lifetime.d b/src/rt/lifetime.d
-index d28edf8c..24c6d902 100644
+index d28edf8c..ac3ad760 100644
 --- a/src/rt/lifetime.d
 +++ b/src/rt/lifetime.d
 @@ -17,7 +17,7 @@ import core.stdc.string;
@@ -47,12 +47,12 @@ index d28edf8c..24c6d902 100644
 -debug(PRINTF) import core.stdc.stdio;
 +debug import core.stdc.stdio;
  static import rt.tlsgc;
- 
+
  alias BlkInfo = GC.BlkInfo;
-@@ -230,6 +230,57 @@ size_t structTypeInfoSize(const TypeInfo ti) pure nothrow @nogc
+@@ -230,6 +230,59 @@ size_t structTypeInfoSize(const TypeInfo ti) pure nothrow @nogc
  private class ArrayAllocLengthLock
  {}
- 
+
 +// break on this to debug stomping prevention allocations
 +export extern(C) void stomping_prevention_trigger ( ) pure nothrow
 +{
@@ -70,7 +70,9 @@ index d28edf8c..24c6d902 100644
 +    import core.stdc.stdio : fflush, stdout, printf;
 +    import core.stdc.string : strcmp;
 +
-+    const failure = new Exception("Stoming prevention has been triggerred");
++    static Exception failure;
++    if (failure is null)
++        failure = new Exception("Stomping prevention has been triggered");
 +
 +    try
 +    {
@@ -104,10 +106,10 @@ index d28edf8c..24c6d902 100644
 +        abort();
 +    }
 +}
- 
+
  /**
    Set the allocated length of the array block.  This is called
-@@ -282,14 +333,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
+@@ -282,14 +335,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
          {
              if(isshared)
              {
@@ -130,7 +132,7 @@ index d28edf8c..24c6d902 100644
              }
          }
          else
-@@ -313,14 +371,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
+@@ -313,14 +373,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
          {
              if(isshared)
              {
@@ -153,7 +155,7 @@ index d28edf8c..24c6d902 100644
              }
          }
          else
-@@ -344,14 +409,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
+@@ -344,14 +411,21 @@ bool __setArrayAllocLength(ref BlkInfo info, size_t newlength, bool isshared, co
          {
              if(isshared)
              {
@@ -176,6 +178,6 @@ index d28edf8c..24c6d902 100644
              }
          }
          else
--- 
-2.13.2
+--
+2.14.1
 

--- a/patches/druntime/0003-Add-message-to-object.Throwable.patch
+++ b/patches/druntime/0003-Add-message-to-object.Throwable.patch
@@ -1,7 +1,7 @@
-From c7677dbdeea2608b4160037841b5c8343c8e4eef Mon Sep 17 00:00:00 2001
+From b215f2b3047ae493e12b33b880b2a5b34ba1d06d Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Tue, 9 Feb 2016 22:24:24 +0200
-Subject: [PATCH 03/17] Add message() to object.Throwable
+Subject: [PATCH 03/18] Add message() to object.Throwable
 
 ---
  src/object.d | 15 +++++++++++++++
@@ -11,10 +11,11 @@ diff --git a/src/object.d b/src/object.d
 index 75ef6701..2bd77b78 100644
 --- a/src/object.d
 +++ b/src/object.d
-@@ -1623,6 +1623,19 @@ class Throwable : Object
+@@ -1622,6 +1622,19 @@ class Throwable : Object
+ 
      string      msg;    /// A message describing the error.
  
-     /**
++    /**
 +     * Get the message describing the error.
 +     * Base behavior is to return the `Throwable.msg` field.
 +     * Override to return some other error message.
@@ -27,10 +28,9 @@ index 75ef6701..2bd77b78 100644
 +        return msg;
 +    }
 +
-+    /**
+     /**
       * The _file name and line number of the D source code corresponding with
       * where the error was thrown from.
-      */
 @@ -1689,6 +1702,8 @@ class Throwable : Object
          sink("@"); sink(file);
          sink("("); sink(sizeToTempString(line, tmpBuff, 10)); sink(")");
@@ -41,5 +41,5 @@ index 75ef6701..2bd77b78 100644
          {
              sink(": "); sink(msg);
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0004-Add-bindings-for-getifaddrs-freeifaddrs.patch
+++ b/patches/druntime/0004-Add-bindings-for-getifaddrs-freeifaddrs.patch
@@ -1,7 +1,7 @@
-From 09d823903fa2d7750fe5c090f0e45d7ab6a9a4c2 Mon Sep 17 00:00:00 2001
+From ea26af213ef6adbef6abe209e19532ddb8d9e8c7 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Fri, 25 Nov 2016 17:04:07 +0100
-Subject: [PATCH 04/17] Add bindings for getifaddrs/freeifaddrs
+Subject: [PATCH 04/18] Add bindings for getifaddrs/freeifaddrs
 
 ---
  mak/COPY                     |  1 +
@@ -112,5 +112,5 @@ index 69f3ba70..a505930b 100644
  	copy $** $@
  
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0005-Add-TCP_-constants-from-Linux-s-netinet-tcp.h.patch
+++ b/patches/druntime/0005-Add-TCP_-constants-from-Linux-s-netinet-tcp.h.patch
@@ -1,7 +1,7 @@
-From e9ef6f9066ef3d32d0b4059c9898448d582b9132 Mon Sep 17 00:00:00 2001
+From b599687886c20416125c0a9c566cfc3f490b6047 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Mon, 28 Nov 2016 18:44:19 +0100
-Subject: [PATCH 05/17] Add TCP_* constants from Linux's netinet/tcp.h
+Subject: [PATCH 05/18] Add TCP_* constants from Linux's netinet/tcp.h
 
 ---
  mak/COPY                             |  1 +
@@ -137,5 +137,5 @@ index a505930b..86cfe022 100644
  	copy $** $@
  
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0006-Add-bindings-for-POSIX-iconv.patch
+++ b/patches/druntime/0006-Add-bindings-for-POSIX-iconv.patch
@@ -1,7 +1,7 @@
-From bd1a27e1fe4b79233ccb96d1a4680b216e2716ca Mon Sep 17 00:00:00 2001
+From 40afb414fbf92069426dbcb7329221cb96a173b6 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Thu, 24 Nov 2016 13:48:53 +0100
-Subject: [PATCH 06/17] Add bindings for POSIX iconv
+Subject: [PATCH 06/18] Add bindings for POSIX iconv
 
 ---
  mak/COPY                   |  1 +
@@ -102,5 +102,5 @@ index 86cfe022..b9d4a649 100644
  	copy $** $@
  
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0007-Add-Linux-specific-sched_setaffinity-and-sched_getaf.patch
+++ b/patches/druntime/0007-Add-Linux-specific-sched_setaffinity-and-sched_getaf.patch
@@ -1,7 +1,7 @@
-From 41ad23ed59863f37120318ca0811611aca18482d Mon Sep 17 00:00:00 2001
+From c70d7d3f38d686a3e9d625b5fe1b29a1dde03610 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Tue, 29 Nov 2016 10:37:13 +0100
-Subject: [PATCH 07/17] Add Linux-specific sched_setaffinity and
+Subject: [PATCH 07/18] Add Linux-specific sched_setaffinity and
  sched_getaffinity
 
 ---
@@ -139,5 +139,5 @@ index b9d4a649..b6875a40 100644
  	copy $** $@
  
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0008-Add-missing-POSIX-libgen.h-header.patch
+++ b/patches/druntime/0008-Add-missing-POSIX-libgen.h-header.patch
@@ -1,7 +1,7 @@
-From e970d632b4e77b9eb459742eb4f943a8e452b643 Mon Sep 17 00:00:00 2001
+From c8e10c0d54b4e4fd870e4b06f3c959b1b70847e7 Mon Sep 17 00:00:00 2001
 From: Leandro Lucarella <leandro.lucarella@sociomantic.com>
 Date: Thu, 24 Nov 2016 20:05:48 -0300
-Subject: [PATCH 08/17] Add missing POSIX <libgen.h> header
+Subject: [PATCH 08/18] Add missing POSIX <libgen.h> header
 
 ---
  mak/COPY                    |  1 +
@@ -80,5 +80,5 @@ index b6875a40..bbe17903 100644
  	copy $** $@
  
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0009-Add-missing-binding-in-SRCS.patch
+++ b/patches/druntime/0009-Add-missing-binding-in-SRCS.patch
@@ -1,7 +1,7 @@
-From e298540c6c02744981ef1eba54fa44270822b317 Mon Sep 17 00:00:00 2001
+From 1c426804512b7e2d80a2f2c51038d3b6d30b6ff7 Mon Sep 17 00:00:00 2001
 From: Mathias Lang <mathias.lang@sociomantic.com>
 Date: Mon, 6 Feb 2017 17:20:57 +0100
-Subject: [PATCH 09/17] Add missing binding in SRCS
+Subject: [PATCH 09/18] Add missing binding in SRCS
 
 The following files were not part of `mak/SRCS`, and thus were not compiled it:
 - src\core\sys\posix\sys\ipc.d
@@ -72,5 +72,5 @@ index 84555ad5..8a0d9819 100644
  	src\core\sys\solaris\sys\priocntl.d \
  	src\core\sys\solaris\sys\types.d \
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0010-Change-version-Linux-to-version-linux.patch
+++ b/patches/druntime/0010-Change-version-Linux-to-version-linux.patch
@@ -1,7 +1,7 @@
-From 130e46348e0c237a3d26fb15a44196e6edfc6765 Mon Sep 17 00:00:00 2001
+From 67609235dea7cb989ebc25cf549fbf7d4eb3cf5b Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Fri, 24 Feb 2017 16:12:35 +0100
-Subject: [PATCH 10/17] Change version(Linux) to version(linux)
+Subject: [PATCH 10/18] Change version(Linux) to version(linux)
 
 ---
  src/core/sys/linux/sched.d           | 2 +-
@@ -35,5 +35,5 @@ index b4acdd23..67458f63 100644
  /// User-settable options (used with setsockopt).
  enum
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0011-Fix-wrong-version-name-in-core.sys.linux.ifaddrs.patch
+++ b/patches/druntime/0011-Fix-wrong-version-name-in-core.sys.linux.ifaddrs.patch
@@ -1,7 +1,7 @@
-From 0996435a80b65f8c903eb2a7a9f0ddb564b4b988 Mon Sep 17 00:00:00 2001
+From 6b693b959031ed9aeb8a76e3f40ba12cad7b877c Mon Sep 17 00:00:00 2001
 From: Tomer Filiba <tomer@weka.io>
 Date: Tue, 21 Feb 2017 18:15:24 +0200
-Subject: [PATCH 11/17] Fix wrong version name in core.sys.linux.ifaddrs
+Subject: [PATCH 11/18] Fix wrong version name in core.sys.linux.ifaddrs
 
 ---
  src/core/sys/linux/ifaddrs.d | 2 +-
@@ -21,5 +21,5 @@ index 1fc5e885..bfdd59bf 100644
  nothrow:
  @nogc:
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0012-linux-time-Add-timer-manipulation-macros.patch
+++ b/patches/druntime/0012-linux-time-Add-timer-manipulation-macros.patch
@@ -1,7 +1,7 @@
-From 163181d5a04cbd49198b4464d7fdec2e8d3b1d26 Mon Sep 17 00:00:00 2001
+From 99119da2c5ff7e2fc48017f74fb9d99168fbe3d4 Mon Sep 17 00:00:00 2001
 From: Leandro Lucarella <leandro.lucarella@sociomantic.com>
 Date: Fri, 25 Nov 2016 17:07:36 -0300
-Subject: [PATCH 12/17] linux/time: Add timer manipulation macros
+Subject: [PATCH 12/18] linux/time: Add timer manipulation macros
 
 ---
  mak/COPY                      |  1 +
@@ -119,5 +119,5 @@ index dbeb58a9..33793da3 100644
  extern (C) nothrow @nogc:
  
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0013-Temporarily-allow-deprecated-GC.usage.patch
+++ b/patches/druntime/0013-Temporarily-allow-deprecated-GC.usage.patch
@@ -1,7 +1,7 @@
-From d4f1a37372a8482cf1f57d1694567a8e0253aa17 Mon Sep 17 00:00:00 2001
+From dc41b57bb689f06c022e86dbd4576e0ec2c4199b Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Tue, 28 Feb 2017 15:28:15 +0100
-Subject: [PATCH 13/17] Temporarily allow deprecated GC.usage
+Subject: [PATCH 13/18] Temporarily allow deprecated GC.usage
 
 Matches old API in D1 runtime
 ---
@@ -28,5 +28,5 @@ index bdc6bc42..0d060d36 100644
       * Adds an internal root pointing to the GC memory block referenced by p.
       * As a result, the block referenced by p itself and any blocks accessible
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0014-Add-bindings-for-POSIX-getdelim-and-getline.patch
+++ b/patches/druntime/0014-Add-bindings-for-POSIX-getdelim-and-getline.patch
@@ -1,7 +1,7 @@
-From 6d1f840a4172969df9badfb8cccb970332ca9a91 Mon Sep 17 00:00:00 2001
+From 0c79bbb3442db757ab0847ae61d67c9bff236b50 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Thu, 26 Jan 2017 18:52:49 +0100
-Subject: [PATCH 14/17] Add bindings for POSIX getdelim and getline
+Subject: [PATCH 14/18] Add bindings for POSIX getdelim and getline
 
 ---
  src/core/sys/posix/stdio.d | 4 ++++
@@ -20,5 +20,5 @@ index 122cba07..6cc30a99 100644
 +ssize_t getdelim (char** lineptr, size_t* n, int delimiter, FILE* stream);
 +ssize_t getline (char** lineptr, size_t* n, FILE* stream);
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0015-Add-eventfd-bindings.patch
+++ b/patches/druntime/0015-Add-eventfd-bindings.patch
@@ -1,7 +1,7 @@
-From 803dfeb2315ef005c8de1d6e6f1d6d645e7aa28c Mon Sep 17 00:00:00 2001
+From 7268c1665cee6af3d9432e673c25fb651fe8a05c Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Tue, 4 Apr 2017 15:27:57 +0200
-Subject: [PATCH 15/17] Add eventfd bindings
+Subject: [PATCH 15/18] Add eventfd bindings
 
 This adds bindings for linux-specific eventfd_* calls.
 
@@ -146,5 +146,5 @@ index bbe17903..97d0fd2f 100644
  	copy $** $@
  
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0016-Add-Fiber-s-guard-page-in-Posix-as-well.patch
+++ b/patches/druntime/0016-Add-Fiber-s-guard-page-in-Posix-as-well.patch
@@ -1,7 +1,7 @@
-From 4f72e04dd6e8230db4847f43ba0c0e1faad8b8e5 Mon Sep 17 00:00:00 2001
+From 0699e066092c895898209b0b4715f79f93084703 Mon Sep 17 00:00:00 2001
 From: Nemanja Boric <nemanja.boric@sociomantic.com>
 Date: Thu, 24 Nov 2016 17:25:39 +0100
-Subject: [PATCH 16/17] Add Fiber's guard page in Posix as well
+Subject: [PATCH 16/18] Add Fiber's guard page in Posix as well
 
 Windows Fiber implementation already uses the fiber stack guard page.
 This brings the similar protection for mmaped fiber stacks, using
@@ -194,5 +194,5 @@ index 75864fb9..c9f87f38 100644
  
          Thread.add( m_ctxt );
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0017-Disable-copying-of-inotify_event.patch
+++ b/patches/druntime/0017-Disable-copying-of-inotify_event.patch
@@ -1,7 +1,7 @@
-From 279ce31447985678fd6f0ed4113365e1dbcc4e04 Mon Sep 17 00:00:00 2001
+From 506653288afbd568bde79e5376ea7efadf139fc7 Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns@gmail.com>
 Date: Fri, 28 Apr 2017 17:04:15 +0200
-Subject: [PATCH 17/17] Disable copying of inotify_event
+Subject: [PATCH 17/18] Disable copying of inotify_event
 
 Pick of https://github.com/dlang/druntime/pull/1795
 ---
@@ -22,5 +22,5 @@ index 41ad65c2..0e273c63 100644
  
  enum: uint
 -- 
-2.13.2
+2.14.1
 

--- a/patches/druntime/0018-Don-t-trigger-stomping-prevention-with-cov.patch
+++ b/patches/druntime/0018-Don-t-trigger-stomping-prevention-with-cov.patch
@@ -1,17 +1,17 @@
-From d1ba6a921faaa77ff0ccac7891ab840be62bd0ea Mon Sep 17 00:00:00 2001
+From f659aad2db1a9d442d14dc5557b0f9eb07ac2eee Mon Sep 17 00:00:00 2001
 From: Mihails Strasuns <mihails.strasuns.contractor@sociomantic.com>
 Date: Thu, 31 Aug 2017 14:49:04 +0300
-Subject: [PATCH] Don't trigger stomping prevention with -cov
+Subject: [PATCH 18/18] Don't trigger stomping prevention with -cov
 
 ---
  src/rt/cover.d | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/src/rt/cover.d b/src/rt/cover.d
-index 23baf15..7c8ba39 100644
+index 50d4520d..b6a8268b 100644
 --- a/src/rt/cover.d
 +++ b/src/rt/cover.d
-@@ -423,6 +423,8 @@ bool readFile(FILE* file, ref char[] buf)
+@@ -427,6 +427,8 @@ bool readFile(FILE* file, ref char[] buf)
          return false;
  
      buf.length = len;
@@ -20,7 +20,7 @@ index 23baf15..7c8ba39 100644
      fseek(file, 0, SEEK_SET);
      if (fread(buf.ptr, 1, buf.length, file) != buf.length)
          assert(0, "fread failed");
-@@ -454,6 +456,7 @@ void splitLines( char[] buf, ref char[][] lines )
+@@ -458,6 +460,7 @@ void splitLines( char[] buf, ref char[][] lines )
              pos = 0;
  
      lines.length = 0;
@@ -28,7 +28,7 @@ index 23baf15..7c8ba39 100644
      for( ; pos < buf.length; ++pos )
      {
          char c = buf[pos];
-@@ -502,12 +505,14 @@ char[] expandTabs( char[] str, int tabsize = 8 )
+@@ -506,12 +509,14 @@ char[] expandTabs( char[] str, int tabsize = 8 )
                      result = null;
                      result.length = str.length + nspaces - 1;
                      result.length = i + nspaces;


### PR DESCRIPTION
Regenerated patches after this change:

```diff
diff --git a/src/rt/lifetime.d b/src/rt/lifetime.d
index 24c6d902..ac3ad760 100644
--- a/src/rt/lifetime.d
+++ b/src/rt/lifetime.d
@@ -247,7 +247,9 @@ void stomping_prevention_trigger_nonpure ( ) nothrow
     import core.stdc.stdio : fflush, stdout, printf;
     import core.stdc.string : strcmp;

-    const failure = new Exception("Stoming prevention has been triggerred");
+    static Exception failure;
+    if (failure is null)
+        failure = new Exception("Stoming prevention has been triggerred");

     try
     {
```

Fixes repeated allocation of exception thrown to get call stack when
trigger is hit.