### PR TITLE
[2.078.3] Override package version

### DIFF
--- a/pkg/dmd-transitional.pkg
+++ b/pkg/dmd-transitional.pkg
@@ -1,3 +1,5 @@
+import subprocess
+
 compiler = 'dmd/generated/linux/debug/64/dmd'
 runtime = 'druntime/generated/linux/release/64/libdruntime.a'
 runtimedbg = 'druntime/generated/linux/debug/64/libdruntime.a'
@@ -10,6 +12,11 @@ OPTS.update(
     maintainer = 'Sociomantic Tsunami <tsunami@sociomantic.com>',
     vendor = 'dunnhumby Germany GmbH',
     depends = FUN.autodeps(compiler),
+    version = subprocess
+        .run(['git', 'describe'], stdout=subprocess.PIPE)
+        .stdout
+        .decode('utf-8')
+        .strip(),
 )
 
 ARGS.extend([


### PR DESCRIPTION
New makd generated convoluted package version identifier for tags
that do not conform SemVer (like dmd-transitional). To be compatible
with old versions, it has to be overriden to plain `git describe`.