### PR TITLE
Add the flag -fPIC to the settings

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -18,7 +18,7 @@ SRC := .
 # Function to checkout code ($1 is the project to checkout)
 define git_clone
 $(RM) -r $1
-git clone --depth 1 --branch "$(DLANG_BASE_VER)" "https://github.com/dlang/$1.git"
+git clone -c protocol.version=1 --depth 1 --branch "$(DLANG_BASE_VER)" "https://github.com/dlang/$1.git"
 git -C $1 am $(addprefix ../,$($(1)_patches))
 endef
 

--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,1 +1,1 @@
-FROM sociomantictsunami/develbase:v6
+FROM sociomantictsunami/develbase:v8

--- a/dmd.conf
+++ b/dmd.conf
@@ -1,2 +1,2 @@
 [Environment]
-DFLAGS=-I/usr/include/d2/dmd-transitional -L--export-dynamic -defaultlib=druntime -version=GLIBC
+DFLAGS=-I/usr/include/d2/dmd-transitional -L--export-dynamic -defaultlib=druntime -version=GLIBC -fPIC


### PR DESCRIPTION
Ubuntu bionic requires builds to use position independent code.
Also the dmd-compiler (upstream) sets in the configuration file the flag -fPIC by default.