### PR TITLE
Remove flag -fPIC from the settings

### DIFF
--- a/dmd.conf
+++ b/dmd.conf
@@ -1,2 +1,2 @@
 [Environment]
-DFLAGS=-I/usr/include/d2/dmd-transitional -L--export-dynamic -defaultlib=druntime -version=GLIBC -fPIC
+DFLAGS=-I/usr/include/d2/dmd-transitional -L--export-dynamic -defaultlib=druntime -version=GLIBC


### PR DESCRIPTION
Revert -fPIC changes added to the configuration file due to it triggers an 
optimisation bug when the optimisation flags -O is combined with -fPIC.

Reverts commit 817d358 merged in #38