### PR TITLE
Backport fix Issue 18534 - Wrong code for ?: operator when compiling with -O

### DIFF
--- a/patches/dmd/0004-fix-Issue-20441-Wrong-code-with-O-fPIC-and-pointer-s.patch
+++ b/patches/dmd/0004-fix-Issue-20441-Wrong-code-with-O-fPIC-and-pointer-s.patch
@@ -1,0 +1,58 @@
+From a4bc86ce3a0c4122fe27c84ae801c42f1c8edeef Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Fri, 13 Dec 2019 00:54:42 -0800
+Subject: [PATCH] fix Issue 20441 - Wrong code with -O -fPIC and pointer
+ subtraction
+
+---
+ src/dmd/backend/cod2.d  |  2 ++
+ test/runnable/testpic.d | 16 ++++++++++++++++
+ 2 files changed, 18 insertions(+)
+
+diff --git a/src/dmd/backend/cod2.d b/src/dmd/backend/cod2.d
+index 0ef56d93e..76d01d448 100644
+--- a/src/dmd/backend/cod2.d
++++ b/src/dmd/backend/cod2.d
+@@ -715,6 +715,8 @@ void cdorth(ref CodeBuilder cdb,elem *e,regm_t *pretregs)
+             break;
+ 
+         case OPrelconst:
++            if (I64 && (config.flags3 & CFG3pic || config.exe == EX_WIN64))
++                goto default;
+             if (sz != REGSIZE)
+                 goto L2;
+             if (segfl[el_fl(e2)] != 3)              /* if not in data segment */
+diff --git a/test/runnable/testpic.d b/test/runnable/testpic.d
+index 4bab07612..ef3ab8667 100644
+--- a/test/runnable/testpic.d
++++ b/test/runnable/testpic.d
+@@ -45,10 +45,26 @@ void test17034()
+ 
+ /***************************************************/
+ 
++// https://issues.dlang.org/show_bug.cgi?id=20441
++
++const(char)* moo(const (char) *s)
++{
++    return s;
++}
++
++void test20441()
++{
++    const(char) *x = "abc".ptr;
++    assert( moo(x) - x == 0 );
++}
++
++/***************************************************/
++
+ int main()
+ {
+     test11310();
+     test17034();
++    test20441();
+ 
+     printf("Success\n");
+     return 0;
+-- 
+2.17.1
+

--- a/patches/dmd/0005-fix-Issue-18534-Wrong-code-for-operator-when-compili.patch
+++ b/patches/dmd/0005-fix-Issue-18534-Wrong-code-for-operator-when-compili.patch
@@ -1,0 +1,84 @@
+From f9ed34003d9b0f533a37850540b02929586e7a76 Mon Sep 17 00:00:00 2001
+From: Walter Bright <walter@walterbright.com>
+Date: Sun, 18 Mar 2018 21:28:53 -0700
+Subject: [PATCH] fix Issue 18534 - Wrong code for ?: operator when compiling
+ with -O
+
+---
+ src/dmd/backend/cod2.c    | 20 +++++++++++++++-----
+ test/runnable/test18534.d | 18 ++++++++++++++++++
+ 2 files changed, 33 insertions(+), 5 deletions(-)
+ create mode 100644 test/runnable/test18534.d
+
+diff --git a/src/dmd/backend/cod2.c b/src/dmd/backend/cod2.c
+index 1b8abefac..6a8cdd33c 100644
+--- a/src/dmd/backend/cod2.c
++++ b/src/dmd/backend/cod2.c
+@@ -1998,9 +1998,19 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
+         targ_size_t v1,v2;
+         int opcode;
+ 
+-        retregs = *pretregs & (ALLREGS | mBP);
+-        if (!retregs)
+-            retregs = ALLREGS;
++        if (sz2 != 1 || I64)
++        {
++            retregs = *pretregs & (ALLREGS | mBP);
++            if (!retregs)
++                retregs = ALLREGS;
++        }
++        else
++        {
++            retregs = *pretregs & BYTEREGS;
++            if (!retregs)
++                retregs = BYTEREGS;
++        }
++
+         cdcmp_flag = 1;
+         v1 = e21->EV.Vllong;
+         v2 = e22->EV.Vllong;
+@@ -2046,7 +2056,7 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
+             {
+                 v1 -= v2;
+                 cdb.genc2(opcode,grex | modregrmx(3,4,reg),v1);   // AND reg,v1-v2
+-                if (I64 && sz1 == 1 && reg >= 4)
++                if (I64 && sz2 == 1 && reg >= 4)
+                     code_orrex(cdb.last(), REX);
+                 if (v2 == 1 && !I64)
+                     cdb.gen1(0x40 + reg);                     // INC reg
+@@ -2054,7 +2064,7 @@ void cdcond(CodeBuilder& cdb,elem *e,regm_t *pretregs)
+                     cdb.gen1(0x48 + reg);                     // DEC reg
+                 else
+                 {   cdb.genc2(opcode,grex | modregrmx(3,0,reg),v2);   // ADD reg,v2
+-                    if (I64 && sz1 == 1 && reg >= 4)
++                    if (I64 && sz2 == 1 && reg >= 4)
+                         code_orrex(cdb.last(), REX);
+                 }
+             }
+diff --git a/test/runnable/test18534.d b/test/runnable/test18534.d
+new file mode 100644
+index 000000000..8d4653dec
+--- /dev/null
++++ b/test/runnable/test18534.d
+@@ -0,0 +1,18 @@
++/* REQUIRED_ARGS: -O
++ * PERMUTE_ARGS:
++ */
++
++// https://issues.dlang.org/show_bug.cgi?id=18534
++
++auto blah(char ch) { return ch; }
++
++auto foo(int i)
++{
++    return blah(i ? 'A' : 'A');
++}
++
++void main()
++{
++    auto c = foo(0);
++    assert(c == 'A');
++}
+-- 
+2.17.1
+


### PR DESCRIPTION
Issue 18534 - Wrong code for ?: operator when compiling with -O

This PR includes the patch for -O -fPIC. Like that one, this is a very serious bug which should be patched in the next dmd-transitional release.
