### PR TITLE
Add the flag -fPIC to the settings

### DIFF
--- a/dmd.conf
+++ b/dmd.conf
@@ -1,2 +1,2 @@
 [Environment]
-DFLAGS=-I/usr/include/d2/dmd-transitional -L--export-dynamic -defaultlib=druntime -version=GLIBC
+DFLAGS=-I/usr/include/d2/dmd-transitional -L--export-dynamic -defaultlib=druntime -version=GLIBC -fPIC


### PR DESCRIPTION
Wrong code -O -fPIC and pointer subtraction was fixed in #40.

Ubuntu bionic requires builds to use position independent code.
Also the dmd-compiler (upstream) sets in the configuration file
the flag -fPIC by default.